### PR TITLE
[User] Prevent undefined method `chomp` for nil

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -38,12 +38,16 @@
   </div>
 
   <div class="form-group mb-3">
-    <%= f.submit t('.update'), class: 'btn btn-primary' %>
+    <%= f.submit t('.update'), class: 'btn btn-success w-100 h-100 text-center' %>
   </div>
 <% end %>
 
-<div class="mb-3">
-  <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: "btn btn-danger" %>
+<div class="row">
+  <div class="col-6">
+    <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: 'btn btn-danger w-100 h-100 text-center' %>
+  </div>
+  <div class="col-6">
+    <%= link_to 'Back', :back, class: 'btn btn-secondary w-100 h-100 text-center'  %>
+  </div>
 </div>
 
-<%= button_to "Back", :back, class: "btn btn-secondary"  %>


### PR DESCRIPTION
If a user visited the site straight to the user edit page, whilst logged in, with no history on the current tab, then the exception would be thrown.

Also did a little layout cleanup