### PR TITLE
[Mailchimp] Change logging style around compliance state

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,15 +86,17 @@ class User < ApplicationRecord
       }
     )
   rescue Gibbon::MailChimpError => e
-    Rollbar.error(e)
-
     begin
       # NOTE: If a member is in compliance state, we are able to resubscribe them by setting their state to pending
       #       this should resend the confirmation email to them so they are no longer in a compliance state
       # References for this change:
       # * https://www.drupal.org/project/mailchimp/issues/2188819
       # * https://stackoverflow.com/questions/42159327/resubscribe-a-user-to-a-mailchimp-list-after-unsubscribe
-      mailchimp_upsert('pending') if e.status_code == 400 && !e.title.downcase.index('member in compliance state').nil?
+      if e.status_code == 400 && !e.title.downcase.index('member in compliance state').nil?
+        mailchimp_upsert('pending')
+      else
+        Rollbar.error(e)
+      end
     rescue Gibbon::MailChimpError => e
       Rollbar.error(e)
     end


### PR DESCRIPTION
If a user is in a compliance state there is no point still putting an error in Rollbar, have it as a warning and then better track if something goes wrong