### PR TITLE
[Volunteering] Keep volunteering link more visible

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,5 +1,6 @@
 class AdminController < ApplicationController
   before_action :authenticate_admin!
+  before_action :fetch_active_event
 
   protected
 
@@ -8,5 +9,9 @@ class AdminController < ApplicationController
 
     render plain: 'You are not permitted to view this'
     false
+  end
+
+  def fetch_active_event
+    @event = Event.active(early_access: current_user&.early_access?)
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,7 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   prepend_before_action :check_captcha, only: [:create]
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :fetch_active_event
 
   private
 
@@ -55,5 +56,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def after_inactive_sign_up_path_for(_resource)
     confirmation_notice_path
+  end
+
+  def fetch_active_event
+    @event = Event.active(early_access: current_user&.early_access?)
   end
 end

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -46,7 +46,7 @@
   <% end %>
 <% end %>
 
-<% if @event.live? || current_user.early_access %>
+<% if @event.live? || (current_user.early_access || current_user.admin) %>
   <p>Looking to volunteer? We now have a <%= link_to 'dedicated page', event_volunteering_index_path(@event) %> for volunteering during London Decompression!</p>
 <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
                     <li class="nav-item">
                       <%= link_to 'Profile', edit_user_registration_path, class: 'nav-link' %>
                     </li>
-                    <% if @event && ((@event.prerelease? || @event.live?) || (current_user.early_access || current_user.admin?)) %>
+                    <% if @event && ((@event.prerelease? && (current_user.early_access || current_user.admin?)) || @event.live?) %>
                       <li class="nav-item">
                         <%= link_to 'Volunteering', event_volunteering_index_path(@event), class: 'nav-link' %>
                       </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
                     <li class="nav-item">
                       <%= link_to 'Profile', edit_user_registration_path, class: 'nav-link' %>
                     </li>
-                    <% if @event && (@event.live? || current_user.early_access || current_user.admin?) %>
+                    <% if @event && ((@event.prerelease? || @event.live?) || (current_user.early_access || current_user.admin?)) %>
                       <li class="nav-item">
                         <%= link_to 'Volunteering', event_volunteering_index_path(@event), class: 'nav-link' %>
                       </li>

--- a/spec/features/volunteer_spec.rb
+++ b/spec/features/volunteer_spec.rb
@@ -8,48 +8,6 @@ RSpec.feature 'Volunteering', type: :feature do
     expect(page).to_not have_text('Volunteer opportunities')
   end
 
-  scenario 'draft event, cannot see volunteer link' do
-    stub_eventbrite_event(tickets_sold_for_code: 0)
-    create(:event, :draft)
-    login
-    expect(page).to_not have_text('Looking to volunteer?')
-  end
-
-  scenario 'prerelease event, cannot see volunteer link' do
-    stub_eventbrite_event(tickets_sold_for_code: 0)
-    create(:event, :prerelease)
-    login
-    expect(page).to_not have_text('Looking to volunteer?')
-  end
-
-  scenario 'prerelease event, early access, can see volunteer link' do
-    stub_eventbrite_event(tickets_sold_for_code: 0)
-    create(:event, :prerelease)
-    login(early_access: true)
-    expect(page).to have_text('Looking to volunteer?')
-  end
-
-  scenario 'live event, early access, can see volunteer link' do
-    stub_eventbrite_event(tickets_sold_for_code: 0)
-    create(:event)
-    login(early_access: true)
-    expect(page).to have_text('Looking to volunteer?')
-  end
-
-  scenario 'live event, can see volunteer link' do
-    stub_eventbrite_event(tickets_sold_for_code: 0)
-    create(:event)
-    login
-    expect(page).to have_text('Looking to volunteer?')
-  end
-
-  scenario 'ended event, early access, cannot see volunteer link' do
-    stub_eventbrite_event(tickets_sold_for_code: 0)
-    create(:event, :ended)
-    login(early_access: true)
-    expect(page).to_not have_text('Looking to volunteer?')
-  end
-
   scenario 'signing up to volunteer successfully' do
     role = create(:volunteer_role, name: 'Ranger', description: 'A description of rangering')
     lead = create(:volunteer, volunteer_role: role, lead: true).user
@@ -97,5 +55,145 @@ RSpec.feature 'Volunteering', type: :feature do
 
     open_email(lead.email)
     expect(current_email).to have_content('James Darling has cancelled their volunteering')
+  end
+
+  scenario 'no event, no volunteer link' do
+    login
+    expect(page).to_not have_text('Volunteering')
+    expect(page).to_not have_text('Looking to volunteer?')
+  end
+
+  scenario 'event in draft mode, no volunteer link' do
+    stub_eventbrite_event(tickets_sold_for_code: 0)
+    create(:event, :draft)
+    login
+    expect(page).to_not have_text('Volunteering')
+    expect(page).to_not have_text('Looking to volunteer?')
+  end
+
+  scenario 'event in pre-release mode, has volunteer link' do
+    stub_eventbrite_event(tickets_sold_for_code: 0)
+    create(:event, :prerelease)
+    login
+    expect(page).to_not have_text('Volunteering')
+    expect(page).to_not have_text('Looking to volunteer?')
+  end
+
+  scenario 'event in pre-release mode, has volunteer link, across profile page' do
+    stub_eventbrite_event(tickets_sold_for_code: 0)
+    create(:event, :prerelease)
+    login
+    expect(page).to_not have_text('Volunteering')
+    expect(page).to_not have_text('Looking to volunteer?')
+    click_link 'Profile'
+    expect(page).to_not have_text('Volunteering')
+  end
+
+  scenario 'event in pre-release mode, early access, has volunteer link' do
+    stub_eventbrite_event(tickets_sold_for_code: 0)
+    create(:event, :prerelease)
+    login(early_access: true)
+    expect(page).to have_text('Volunteering')
+    expect(page).to have_text('Looking to volunteer?')
+  end
+
+  scenario 'event in pre-release mode, admin, has volunteer link' do
+    stub_eventbrite_event(tickets_sold_for_code: 0)
+    create(:event, :prerelease)
+    login(admin: true)
+    expect(page).to have_text('Volunteering')
+    expect(page).to have_text('Looking to volunteer?')
+  end
+
+  scenario 'event in pre-release mode, early access and admin, has volunteer link' do
+    stub_eventbrite_event(tickets_sold_for_code: 0)
+    create(:event, :prerelease)
+    login(early_access: true, admin: true)
+    expect(page).to have_text('Volunteering')
+    expect(page).to have_text('Looking to volunteer?')
+  end
+
+  scenario 'event in pre-release mode, admin, has volunteer link, across users admin pages' do
+    stub_eventbrite_event(tickets_sold_for_code: 0)
+    create(:event, :prerelease)
+    login(admin: true)
+    expect(page).to have_text('Volunteering')
+    expect(page).to have_text('Looking to volunteer?')
+    click_link 'Users'
+    expect(page).to have_text('Volunteering')
+  end
+
+  scenario 'event live, has volunteer link' do
+    stub_eventbrite_event(tickets_sold_for_code: 0)
+    create(:event)
+    login
+    expect(page).to have_text('Volunteering')
+    expect(page).to have_text('Looking to volunteer?')
+  end
+
+  scenario 'event live, early access, has volunteer link' do
+    stub_eventbrite_event(tickets_sold_for_code: 0)
+    create(:event)
+    login(early_access: true)
+    expect(page).to have_text('Volunteering')
+    expect(page).to have_text('Looking to volunteer?')
+  end
+
+  scenario 'event live, admin, has volunteer link' do
+    stub_eventbrite_event(tickets_sold_for_code: 0)
+    create(:event)
+    login(admin: true)
+    expect(page).to have_text('Volunteering')
+    expect(page).to have_text('Looking to volunteer?')
+  end
+
+  scenario 'event live, early access and admin, has volunteer link' do
+    stub_eventbrite_event(tickets_sold_for_code: 0)
+    create(:event)
+    login(early_access: true, admin: true)
+    expect(page).to have_text('Volunteering')
+    expect(page).to have_text('Looking to volunteer?')
+  end
+
+  scenario 'event live, admin, has volunteer link across users admin pages' do
+    stub_eventbrite_event(tickets_sold_for_code: 0)
+    create(:event)
+    login(admin: true)
+    expect(page).to have_text('Volunteering')
+    expect(page).to have_text('Looking to volunteer?')
+    click_link 'Users'
+    expect(page).to have_text('Volunteering')
+  end
+
+  scenario 'event ended, no volunteer link' do
+    stub_eventbrite_event(tickets_sold_for_code: 0)
+    create(:event, :ended)
+    login
+    expect(page).to_not have_text('Volunteering')
+    expect(page).to_not have_text('Looking to volunteer?')
+  end
+
+  scenario 'event ended, early access, no volunteer link' do
+    stub_eventbrite_event(tickets_sold_for_code: 0)
+    create(:event, :ended)
+    login(early_access: true)
+    expect(page).to_not have_text('Volunteering')
+    expect(page).to_not have_text('Looking to volunteer?')
+  end
+
+  scenario 'event ended, admin, no volunteer link' do
+    stub_eventbrite_event(tickets_sold_for_code: 0)
+    create(:event, :ended)
+    login(admin: true)
+    expect(page).to_not have_text('Volunteering')
+    expect(page).to_not have_text('Looking to volunteer?')
+  end
+
+  scenario 'event ended, early access and admin, no volunteer link' do
+    stub_eventbrite_event(tickets_sold_for_code: 0)
+    create(:event, :ended)
+    login(early_access: true, admin: true)
+    expect(page).to_not have_text('Volunteering')
+    expect(page).to_not have_text('Looking to volunteer?')
   end
 end


### PR DESCRIPTION
Previously we weren't checking for the event for all the controllers meaning we would end up with a situation where the link appeared and vanished