### PR TITLE
[Cache] Move to redis gem as redis-rails is out of date

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'bootsnap', '~> 1.18', '>= 1.18.4', require: false
 gem 'rubocop', '1.66.1'
 gem 'rollbar'
 
-gem 'redis-rails'
+gem 'redis'
 
 gem 'devise'
 gem 'devise-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,24 +354,8 @@ GEM
     recaptcha (5.17.0)
     redis (5.3.0)
       redis-client (>= 0.22.0)
-    redis-actionpack (5.4.0)
-      actionpack (>= 5, < 8)
-      redis-rack (>= 2.1.0, < 4)
-      redis-store (>= 1.1.0, < 2)
-    redis-activesupport (5.3.0)
-      activesupport (>= 3, < 8)
-      redis-store (>= 1.3, < 2)
     redis-client (0.22.2)
       connection_pool
-    redis-rack (3.0.0)
-      rack-session (>= 0.2.0)
-      redis-store (>= 1.2, < 2)
-    redis-rails (5.0.2)
-      redis-actionpack (>= 5.0, < 6)
-      redis-activesupport (>= 5.0, < 6)
-      redis-store (>= 1.2, < 2)
-    redis-store (1.11.0)
-      redis (>= 4, < 6)
     regexp_parser (2.9.2)
     reline (0.5.10)
       io-console (~> 0.5)
@@ -539,7 +523,7 @@ DEPENDENCIES
   puma (~> 6.4, >= 6.4.2)
   rails (~> 7.2)
   recaptcha
-  redis-rails
+  redis
   rollbar
   rspec-rails
   rubocop (= 1.66.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ Bundler.require(*Rails.groups)
 
 module LondonDecomMembership
   class Application < Rails::Application
+    cache_key = 'ldm'
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
 
@@ -26,21 +28,17 @@ module LondonDecomMembership
 
     if (ENV.fetch('REDIS_URL', nil) && ENV.fetch('REDIS_PORT', nil)) && !Rails.env.test?
       config.cache_store = :redis_cache_store, {
-        url: ENV.fetch('REDIS_URL', nil), port: ENV.fetch('REDIS_PORT', nil), db: 0, namespace: 'cache',
+        url: ENV.fetch('REDIS_URL', nil),
+        port: ENV.fetch('REDIS_PORT', nil),
+        db: 0,
+        namespace: "_#{cache_key.downcase}_cache",
         expires_in: 90.minutes
       }
 
       config.action_controller.enable_fragment_cache_logging = !Rails.env.production?
 
-      config.session_store :redis_store,
-                           servers: [{
-                             url: ENV.fetch('REDIS_URL', nil),
-                             port: ENV.fetch('REDIS_PORT', nil),
-                             db: 0,
-                             namespace: 'session'
-                           }],
-                           expire_after: 90.minutes,
-                           key: "_#{Rails.application.class.module_parent_name.downcase}_session",
+      config.session_store expire_after: 90.minutes,
+                           key: "_#{cache_key.downcase}_session",
                            threadsafe: true,
                            secure: true
     end


### PR DESCRIPTION
We weren't getting fault tolerance and the newer features that the built in redis gem affords us