### PR TITLE
[Redis] Use redis-actionpack for session caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'rubocop', '1.66.1'
 gem 'rollbar'
 
 gem 'redis'
+gem 'redis-actionpack'
 
 gem 'devise'
 gem 'devise-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,8 +354,17 @@ GEM
     recaptcha (5.17.0)
     redis (5.3.0)
       redis-client (>= 0.22.0)
+    redis-actionpack (5.4.0)
+      actionpack (>= 5, < 8)
+      redis-rack (>= 2.1.0, < 4)
+      redis-store (>= 1.1.0, < 2)
     redis-client (0.22.2)
       connection_pool
+    redis-rack (3.0.0)
+      rack-session (>= 0.2.0)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.11.0)
+      redis (>= 4, < 6)
     regexp_parser (2.9.2)
     reline (0.5.10)
       io-console (~> 0.5)
@@ -524,6 +533,7 @@ DEPENDENCIES
   rails (~> 7.2)
   recaptcha
   redis
+  redis-actionpack
   rollbar
   rspec-rails
   rubocop (= 1.66.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,8 +37,14 @@ module LondonDecomMembership
 
       config.action_controller.enable_fragment_cache_logging = !Rails.env.production?
 
-      config.session_store expire_after: 90.minutes,
-                           key: "_#{cache_key.downcase}_session",
+      config.session_store :redis_store,
+                           servers: [{
+                             url: ENV.fetch('REDIS_URL', nil),
+                             port: ENV.fetch('REDIS_PORT', nil),
+                             db: 0,
+                             namespace: "_#{cache_key.downcase}_session"
+                           }],
+                           expires_after: 90.minutes,
                            threadsafe: true,
                            secure: true
     end


### PR DESCRIPTION
Does leave us at risk if redis goes down again, but it's better to be using the cache for session storage especially with auto-timeouts