### PR TITLE
[Event] Handle situation where user might have multiple tickets

### DIFF
--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -9,7 +9,7 @@
     <% end %>
   </p>
 <% elsif @event.live? || current_user.early_access %>
-  <% if @event.tickets_sold_for_code(current_user.membership_number) > 0 %>
+  <% if @event.tickets_sold_for_code(current_user.membership_number) > 0 && @event.available_tickets_for_code(current_user.membership_number) == 0 %>
     <p>
       You have bought the
       <%= pluralize(@event.tickets_sold_for_code(current_user.membership_number), 'ticket') %>
@@ -17,7 +17,7 @@
     </p>
   <% else %>
     <p>
-      <% if @event.tickets_sold_for_code(current_user.membership_number) > 0 %>
+      <% if @event.tickets_sold_for_code(current_user.membership_number) > 0 && @event.available_tickets_for_code(current_user.membership_number) > 0 %>
         You have already bought
         <%= pluralize(@event.tickets_sold_for_code(current_user.membership_number), 'ticket') %>.
         You can buy

--- a/spec/features/tickets_spec.rb
+++ b/spec/features/tickets_spec.rb
@@ -26,12 +26,30 @@ RSpec.feature 'Tickets', type: :feature do
     expect(page).to have_text('You can buy 1 ticket')
   end
 
-  scenario 'user has 1 available tickets and bought 1' do
+  scenario 'user has bought only ticket' do
     stub_eventbrite_event(available_tickets_for_code: 0, tickets_sold_for_code: 1)
     create(:event)
     login
 
     expect(page).to_not have_text('Buy Ticket')
     expect(page).to have_text('You have bought the 1 ticket available to you')
+  end
+
+  scenario 'user has 2 available tickets' do
+    stub_eventbrite_event
+    create(:event)
+    login
+
+    expect(page).to have_text('Buy Ticket')
+    expect(page).to have_text('You can buy 2 tickets')
+  end
+
+  scenario 'user has 1 available tickets and bought 1' do
+    stub_eventbrite_event(available_tickets_for_code: 1, tickets_sold_for_code: 1)
+    create(:event)
+    login
+
+    expect(page).to have_text('Buy Ticket')
+    expect(page).to have_text('You have already bought 1 ticket. You can buy 1 more ticket')
   end
 end


### PR DESCRIPTION
For some reason these tests were missing, restoring them so we can test different cases on the home page.

Fixed the logic in _event.html.erb where we previously wouldn't have gotten into the mutli-ticket code