### PR TITLE
[Admin] Give admins a way to clear a cached ticket

### DIFF
--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -7,11 +7,16 @@
   <%= form.submit 'Update user details', class: "btn btn-success w-100"  %>
 <% end %>
 <div class="row mt-3">
-  <div class="col-6">
-    <%= button_to 'Delete', admin_user_path(@user), method: :delete, data: {confirm: 'Are you sure? This is irreversible'}, class: "btn btn-danger w-100" %>
+  <div class="col-4">
+    <% if @has_cache_entry %>
+      <%= button_to 'Clear Cached User Ticket', admin_clear_discount_from_cache_admin_user_path(@user), method: :post, class: "btn btn-danger w-100" %>
+      <p><i class="text-muted">This button is ONLY to be used if a user is reporting they cannot see a ticket on the members site, despite having one assigned</i></p>
+    <% else %>
+      <button class="btn btn-secondary w-100" disabled>User has no cached ticket</button>
+    <% end %>
   </div>
 
-  <div class="col-6">
+  <div class="col-4">
     <% if @user.ticket_type == :direct %>
       <button class="btn btn-secondary w-100" disabled>Has direct sale</button>
     <% else %>
@@ -19,5 +24,9 @@
         <%= form.submit 'Give direct access', class: 'btn btn-secondary w-100' %>
       <% end %>
     <% end %>
+  </div>
+
+  <div class="col-4">
+    <%= button_to 'Delete', admin_user_path(@user), method: :delete, data: {confirm: 'Are you sure? This is irreversible'}, class: "btn btn-danger w-100" %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
       member do
         patch :give_direct_sale
         post :resend_email
+        post :admin_clear_discount_from_cache
       end
     end
     resources :membership_codes
@@ -27,7 +28,7 @@ Rails.application.routes.draw do
     end
   end
   resources :events, only: %i[patch] do
-    patch :clear_discount_from_cache
+    patch :clear_discount_from_cache # TODO: Move this into a members do block
     resources :volunteer_roles, only: [] do
       resources :volunteers, only: %i[index new create destroy update]
     end

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -31,6 +31,25 @@ RSpec.feature 'Users Admin', type: :feature do
     expect(page).to have_text('test_mail_user@example.com')
   end
 
+  scenario 'no event, clear cache button greyed out' do
+    login(admin: true)
+    create(:user, email: 'test_mail_user@example.com')
+    click_link 'Users'
+    expect(page).to have_text('test_mail_user@example.com')
+    find_all("a[text()='Edit']").last.click
+    expect(page).to have_text('User has no cached ticket')
+  end
+
+  scenario 'clear cache button greyed out' do
+    stub_eventbrite_event
+    login(admin: true)
+    create(:user, email: 'test_mail_user@example.com')
+    click_link 'Users'
+    expect(page).to have_text('test_mail_user@example.com')
+    find_all("a[text()='Edit']").last.click
+    expect(page).to have_text('User has no cached ticket')
+  end
+
   scenario 'as not an admin' do
     stub_eventbrite_event
     login(admin: false)


### PR DESCRIPTION
We need to allow admins to do this so that if a users ticket gets stuck, we can cleanly remove it from the cache so the next reload of the users page is with the updated data