### PR TITLE
[Chore] Update action_cable reference to actioncable

### DIFF
--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -1,7 +1,7 @@
 // Action Cable provides the framework to deal with WebSockets in Rails.
 // You can generate new channels where WebSocket features live using the `rails generate channel` command.
 //
-//= require action_cable
+//= require actioncable
 //= require_self
 //= require_tree ./channels
 


### PR DESCRIPTION
There was warning messages to update this as `action_cable` is being removed in favor of `actioncable`